### PR TITLE
fix: UPC-A変換でチェックディジット手前の桁が欠落する問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,8 +663,9 @@
         await sleep(300 / animationSpeed);
 
         // 2. Source Digits (Blue)
+        let p6Index = p6Value <= 2 ? 3 : (p6Value >= 5 ? 10 : -1);
         for (let i = 1; i < 11; i++) {
-          if (upcaDigits[i] !== '0' && i !== (p6Value <= 2 ? 3 : 10)) {
+          if (upcaDigits[i] !== '0' && i !== p6Index) {
             await sleep(100 / animationSpeed);
             upcaBoxes[i].textContent = upcaDigits[i];
             upcaBoxes[i].className = 'digit-box source animating';
@@ -673,7 +674,6 @@
         
         // 3. Moved P6 (Orange)
         await sleep(300 / animationSpeed);
-        let p6Index = p6Value <= 2 ? 3 : (p6Value >= 5 ? 10 : -1);
         if (p6Index !== -1) {
           upcaBoxes[p6Index].textContent = upcaDigits[p6Index];
           upcaBoxes[p6Index].className = 'digit-box moved animating';


### PR DESCRIPTION
P6のインデックス計算をアニメーションループの前に移動し、
P6が配置される位置を正確に除外するように修正。
これによりP6=5-9の場合でもインデックス10の桁が正しく表示されるようになった。